### PR TITLE
docs: Update `BUILDING.md` with Node.js and Yarn requirements for MacOS

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -6,8 +6,11 @@ This is the guide to building the latest version of SCRCPY+ for all operating sy
 - Windows
     - [Node v18](https://nodejs.org/en/)
     - Yarn Package Manager // run `npm i -g yarn`
-- Linux / Mac
+- Linux
     - [Node v18](https://nodejs.org/en/)
+    - Yarn Package Manager // run `sudo npm i -g yarn`
+- MacOS
+    - [Node v16](https://nodejs.org/en/)
     - Yarn Package Manager // run `sudo npm i -g yarn`
 
 ## Build


### PR DESCRIPTION
## Description

Hi @Frontesque

Previously, I got an error when I tried to build the project on macOS. I found that the error is caused by compatibility issues with my node version. Then I downgraded it to v16.20.2 and it works. I think it would be helpful to add this information to the documentation.

## Step to reproduce

1. Clone the project
2. Set the node version to v18.20.3 or higher
3. Run `yarn install`
4. Run `yarn build`

## Expected behaviour

<img width="1002" alt="Screenshot 2024-06-06 at 03 18 01" src="https://github.com/Frontesque/scrcpy-plus/assets/48643295/1e3aa04d-727c-4b9c-a765-5368e2d86cb7">

The project should be built successfully.

## Actual behaviour

<img width="1552" alt="Screenshot 2024-06-06 at 03 22 29" src="https://github.com/Frontesque/scrcpy-plus/assets/48643295/7ebfbd5c-448e-469d-a261-c75f81cb6be4">

The project failed to build, with an error message:

```bash
Error: error:0308010C:digital envelope routines::unsupported
```

## Additional Information

- Operating System: macOS 14.4.1 (23E224)