### PR TITLE
Add homebrew to exec

### DIFF
--- a/src/renderer/plugins/modules/execute.js
+++ b/src/renderer/plugins/modules/execute.js
@@ -16,7 +16,6 @@ module.exports = (cmd) => {
             opts["shell"] = "/bin/zsh"
             opts["env"] = process.env
             opts["env"]["PATH"] += ":/opt/homebrew/bin"
-            // command = "source ~/.zshrc; " + command;
         }
         exec(
             command, 

--- a/src/renderer/plugins/modules/execute.js
+++ b/src/renderer/plugins/modules/execute.js
@@ -2,16 +2,29 @@ const { exec } = require("child_process");
 const os = require('os');
 
 module.exports = (cmd) => {
-    const isWindows = os.type() == "Windows_NT" ? true : false;
+    const isWindows = os.type() == "Windows_NT";
+    const isMac = os.type() == "Darwin";
 
     return new Promise((resolve, reject) => {
-
+        let command = cmd
+        let opts = {};
+        // CD to PreInstalled SCRCPY On Windows
+        if (isWindows) {
+            command = 'cd '+process.env.scrcpyPath+ '&' + command;
+        }
+        if (isMac) {
+            opts["shell"] = "/bin/zsh"
+            opts["env"] = process.env
+            opts["env"]["PATH"] += ":/opt/homebrew/bin"
+            // command = "source ~/.zshrc; " + command;
+        }
         exec(
-          (isWindows ? ('cd '+process.env.scrcpyPath+ '&') : ('')) + cmd, // CD to PreInstalled SCRCPY On Windows
-          (error, stdout, stderr) => {
-            if (error || stderr) reject(error || stderr);
-            resolve(stdout);
-          }
+            command, 
+            opts,
+            (error, stdout, stderr) => {
+                if (error || stderr) reject(error || stderr);
+                resolve(stdout);
+            }
         );
     
     });


### PR DESCRIPTION
This forces env path to include homebrew bin location.

I noticed if I ran the built `scrcpy+.app` from the terminal everything was okay, but if I double clicked the app I wouldn't beable to find scrcpy.

I removed some nonsense code `? true : false;`

And changed to using if instead of the more difficult to read `isTrue ? thenThis : otherwiseThat`